### PR TITLE
Fix bool matcher in Xcode 10

### DIFF
--- a/Classes/OCMockitoSwiftAdapter.m
+++ b/Classes/OCMockitoSwiftAdapter.m
@@ -39,7 +39,7 @@ static const char *unsignedLongLongType = "Q";
 
 static const char *floatType = "f";
 static const char *doubleType = "d";
-static const char *boolType = "bool";
+static const char *boolType = "B";
 
 static const char *selectorType = ":";
 

--- a/Example/OCMockitoSwiftTests/Fixtures/TestClass.h
+++ b/Example/OCMockitoSwiftTests/Fixtures/TestClass.h
@@ -18,6 +18,8 @@ typedef NS_OPTIONS(NSUInteger, TestClassOptions) {
 
 - (void)doSomethingWithInt:(NSUInteger)integer;
 
+- (void)doSomethingWithBoolean:(BOOL)boolean;
+
 - (NSString *)returnObjectMethodNoArguments;
 
 - (NSInteger)returnIntegerMethodNoArguments;

--- a/Example/OCMockitoSwiftTests/Fixtures/TestClass.m
+++ b/Example/OCMockitoSwiftTests/Fixtures/TestClass.m
@@ -18,6 +18,10 @@
     NSLog(@"Hello: %ld", integer);
 }
 
+- (void)doSomethingWithBoolean:(BOOL)boolean {
+    NSLog(@"Hello");
+}
+
 - (NSString *)returnObjectMethodNoArguments {
     return @"Hello World!";
 }

--- a/Example/OCMockitoSwiftTests/Fixtures/TestProtocol.h
+++ b/Example/OCMockitoSwiftTests/Fixtures/TestProtocol.h
@@ -12,6 +12,8 @@
 
 - (void)doSomethingWithInt:(NSUInteger)integer;
 
+- (void)doSomethingWithBoolean:(BOOL)boolean;
+
 - (NSString *)returnObjectMethodNoArguments;
 
 @end

--- a/Example/OCMockitoSwiftTests/OCMockitoSwiftTests.swift
+++ b/Example/OCMockitoSwiftTests/OCMockitoSwiftTests.swift
@@ -134,6 +134,17 @@ class OCMockitoSwiftSpec: QuickSpec {
 
                         }
 
+                        context("only boolean") {
+                            context("when there was interaction with mock") {
+                                beforeEach {
+                                    testMock.doSomething(withBoolean: true)
+                                }
+                                it("should NOT throw an exception") {
+                                    verify(testMock) { (#selector(TestClass.doSomething(withBoolean:)), [Bool(true)]) }
+                                }
+                            }
+                        }
+
                         context("mixed: class type and primitives") {
 
                         }


### PR DESCRIPTION
In Xcode 10 mocking bool argument doesn't work.