### PR TITLE
Add caller's filename and line number to the fail report

### DIFF
--- a/Classes/OCMockito.swift
+++ b/Classes/OCMockito.swift
@@ -36,24 +36,44 @@ public func mockProtocol(_ type: Protocol) -> Any {
     return OCMockitoSwiftAdapter.mockProtocol(type)
 }
 
-public func verify(_ mock: Any, count: UInt = 1, closure: () -> (Selector)) {
+public func verify(_ mock: Any,
+                   count: UInt = 1,
+                   fileName: String = #file,
+                   lineNumber: Int32 = #line,
+                   closure: () -> (Selector)) {
     let selector = closure()
-    OCMockitoSwiftAdapter.verify(mock, count: count, selector: selector, arguments: [], matchers: [:])
+    OCMockitoSwiftAdapter.verify(mock, count: count, selector: selector, arguments: [], matchers: [:],
+                                 fileName: fileName, lineNumber: lineNumber)
 }
 
-public func verify(_ mock: Any, count: UInt = 1, closure: () -> (Selector, arguments: [Any])) {
+public func verify(_ mock: Any,
+                   count: UInt = 1,
+                   fileName: String = #file,
+                   lineNumber: Int32 = #line,
+                   closure: () -> (Selector, arguments: [Any])) {
     let (sel, arguments) = closure()
-    OCMockitoSwiftAdapter.verify(mock, count: count, selector: sel, arguments: arguments, matchers: [:])
+    OCMockitoSwiftAdapter.verify(mock, count: count, selector: sel, arguments: arguments, matchers: [:],
+                                 fileName: fileName, lineNumber: lineNumber)
 }
 
-public func verify(_ mock: Any, count: UInt = 1, closure: () -> (Selector, matchers: [Int: Any])) {
+public func verify(_ mock: Any,
+                   count: UInt = 1,
+                   fileName: String = #file,
+                   lineNumber: Int32 = #line,
+                   closure: () -> (Selector, matchers: [Int: Any])) {
     let (sel, matchers) = closure()
-    OCMockitoSwiftAdapter.verify(mock, count: count, selector: sel, arguments: [], matchers: matchers)
+    OCMockitoSwiftAdapter.verify(mock, count: count, selector: sel, arguments: [], matchers: matchers,
+                                 fileName: fileName, lineNumber: lineNumber)
 }
 
-public func verify(_ mock: Any, count: UInt = 1, closure: () -> (Selector, arguments: [Any], matchers: [Int: Any])) {
+public func verify(_ mock: Any,
+                   count: UInt = 1,
+                   fileName: String = #file,
+                   lineNumber: Int32 = #line,
+                   closure: () -> (Selector, arguments: [Any], matchers: [Int: Any])) {
     let (sel, arguments, matchers) = closure()
-    OCMockitoSwiftAdapter.verify(mock, count: count, selector: sel, arguments: arguments, matchers: matchers)
+    OCMockitoSwiftAdapter.verify(mock, count: count, selector: sel, arguments: arguments, matchers: matchers,
+                                 fileName: fileName, lineNumber: lineNumber)
 }
 
 public func given(_ mock: Any, closure: () -> (Selector, arguments: [Any], willReturn: Any)) {

--- a/Classes/OCMockitoSwiftAdapter.h
+++ b/Classes/OCMockitoSwiftAdapter.h
@@ -33,7 +33,9 @@
          count:(NSUInteger)executionCount
       selector:(SEL)selector
      arguments:(NSArray *)arguments
-      matchers:(NSDictionary *)matchers;
+      matchers:(NSDictionary *)matchers
+      fileName:(NSString *)fileName
+    lineNumber:(int)lineNumber;
 
 + (void)given:(id)mock
      selector:(SEL)selector

--- a/Classes/OCMockitoSwiftAdapter.m
+++ b/Classes/OCMockitoSwiftAdapter.m
@@ -63,8 +63,10 @@ static const char *selectorType = ":";
          count:(NSUInteger)executionCount
       selector:(SEL)selector
      arguments:(NSArray *)arguments
-      matchers:(NSDictionary *)matchers {
-    id mocking = verifyCount(mock, times(executionCount));
+      matchers:(NSDictionary *)matchers
+      fileName:(NSString *)fileName
+    lineNumber:(int)lineNumber {
+    id mocking = MKTVerifyCountWithLocation(mock, times(executionCount), self, fileName.UTF8String, lineNumber);
     for (id key in matchers.allKeys) {
         id matcher = matchers[key];
         [mocking withMatcher:matcher forArgument:[key unsignedIntValue]];

--- a/Example/OCMockitoSwift.xcodeproj/project.pbxproj
+++ b/Example/OCMockitoSwift.xcodeproj/project.pbxproj
@@ -423,7 +423,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-OCMockitoSwiftTests/Pods-OCMockitoSwiftTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-OCMockitoSwiftTests/Pods-OCMockitoSwiftTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/OCHamcrest/OCHamcrest.framework",
 				"${BUILT_PRODUCTS_DIR}/OCMockito/OCMockito.framework",
@@ -440,7 +440,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OCMockitoSwiftTests/Pods-OCMockitoSwiftTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OCMockitoSwiftTests/Pods-OCMockitoSwiftTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - OCHamcrest (7.0.2)
   - OCMockito (5.0.1):
     - OCHamcrest (~> 7.0)
-  - OCMockitoSwift (0.4.0):
+  - OCMockitoSwift (0.4.1):
     - OCHamcrest (~> 7.0)
     - OCMockito (~> 5.0.1)
   - Quick (1.3.2)
@@ -29,9 +29,9 @@ SPEC CHECKSUMS:
   Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
   OCHamcrest: 706bfbf69a3df55a873bad096014e80e2e8ca93c
   OCMockito: 063837a086c058e764fcd23e771089c1759e7197
-  OCMockitoSwift: e292c378da8c6a52fe36102a539b8efd21a0ed53
+  OCMockitoSwift: 8d0fb2c936bfe64a993bf6c3a252bbe73478526c
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
 
 PODFILE CHECKSUM: bf0ced3f13117cc94de158a68ebe5be7a12db901
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1


### PR DESCRIPTION
Hey, Aleksander!
I've added file name and line number to the fail report of the test.
Now it prints the actual line number, where the `verify(mock) ...` function is called, i.e.
```
failed: caught "HCGenericTestFailure", "/path/to/MyTests.swift:123: matcher error: Wanted but not invoked:
myMethod:ANYTHING withArguments:ANYTHING
```
Before the changes it used to always print `OCMockitoSwiftAdapter.m:67` where the `verifyCount()` call is used to be.

Please, take a look, and merge it if you like.

I've run all the tests in the example before and after the changes. All passed.

Thanks! 😊
