### PR TITLE
bug/Updates OCMockito commit

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "mateuszszklarek/OCMockito" "fix/M1_support"
+github "mateuszszklarek/OCMockito" "5f92a15c9fce07e63ab81f2ed958420c7c1363d9"


### PR DESCRIPTION
It turned out that `OCMockito` has the dependency to OCHamcrest that is not in sync in `Cartfile` and this is causing a problem when building dependencies using Carthage:
```
error: There is no XCFramework found at '/Users/adriansliwa/Developer/fabulous-ios/fabulous-ios/Carthage/Checkouts/OCMockito/Frameworks/OCHamcrest-8.0.0/OCHamcrest.xcframework'. (in target 'OCMockito-iOS' from project 'OCMockito')
```
When setting OCMockito to a specific commit one before introducing an update to version 8.0.0 of OCHamcrest, Carthage build is successful.